### PR TITLE
Feature/299 market name on respondant list

### DIFF
--- a/server/static/survey/assets/js/controllers/RespondantDetail.js
+++ b/server/static/survey/assets/js/controllers/RespondantDetail.js
@@ -11,8 +11,7 @@ angular.module('askApp')
         });
         $scope.respondent = data;
     });
-        
-    
+
     $scope.uuid = $routeParams.uuidSlug;
     $scope.surveySlug = $routeParams.surveySlug;
 

--- a/server/static/survey/assets/js/controllers/RespondantList.js
+++ b/server/static/survey/assets/js/controllers/RespondantList.js
@@ -44,7 +44,7 @@ angular.module('askApp')
                     message: data.message
                 });
                 $scope.charts.sort(function (a,b) { return a-b;})
-            });    
+            });
 
             url = ['/reports/crosstab', $routeParams.surveySlug, 'survey-site', 'cost'].join('/');
                 url = url + '?startdate=' + $scope.filter.startDate.toString('yyyyMMdd');
@@ -62,8 +62,8 @@ angular.module('askApp')
                     order: 1,
                     message: data.message
                 });
-                $scope.charts.sort(function (a,b) { return a-b;})    
-                
+                $scope.charts.sort(function (a,b) { return a-b;})
+
             });
 
             url = ['/reports/crosstab', $routeParams.surveySlug, 'survey-site', 'total-weight'].join('/');
@@ -84,13 +84,12 @@ angular.module('askApp')
                     endDate: $scope.filter.endDate,
                     message: data.message
                 });
-                $scope.charts.sort(function (a,b) { return a-b;})    
-                
-            });    
+                $scope.charts.sort(function (a,b) { return a-b;})
+            });
         }
-        
+
     }, true);
-    
+
 
 
     $http.get('/api/v1/surveyreport/' + $routeParams.surveySlug + '/?format=json').success(function(data) {
@@ -113,11 +112,10 @@ angular.module('askApp')
 
             }
         });
-        
+
 
     }).success(function() {
 
-         
     });
 
     $scope.getRespondents = function (url) {
@@ -139,13 +137,13 @@ angular.module('askApp')
             $scope.meta = data.meta;
         });
     }
-    
+
 
     $scope.getQuestionByUri = function (uri) {
         return _.findWhere($scope.survey.questions, {'resource_uri': uri});
     };
 
     $scope.getQuestionBySlug = function (slug) {
-		return _.findWhere($scope.survey.questions, {'slug': slug});
+        return _.findWhere($scope.survey.questions, {'slug': slug});
     };
 });

--- a/server/static/survey/styles/main.css
+++ b/server/static/survey/styles/main.css
@@ -45,6 +45,9 @@ border: 1px solid #e5e5e5;
 .respondent-table {
   min-height: 370px;
 }
+.respondent-table th {
+    border-top: 0px;
+}
 
 .form-signin .form-signin-heading,
 .form-signin .checkbox {

--- a/server/static/survey/views/RespondantList.html
+++ b/server/static/survey/views/RespondantList.html
@@ -13,6 +13,7 @@
             <tbody>
                 <tr ng-repeat="respondent in respondents">
                     <td>{{ respondent.user.username }}</td>
+                    <td>TODO: MARKET NAME GOES HERE</td>
                     <td>{{ respondent.ts|validDate: 'dd-MM-yyyy HH:mm' }}</td>
                     <td><a href="#/RespondantDetail/{{survey.slug}}/{{ respondent.uuid }}">Responses ({{respondent.responses.length}})</a></td>
                 </tr>

--- a/server/static/survey/views/RespondantList.html
+++ b/server/static/survey/views/RespondantList.html
@@ -11,9 +11,21 @@
     <div class="respondent-table">
         <table class="table" ng-class="{ 'loading': respondentsLoading }">
             <tbody>
+                <tr>
+                    <th>Username</th>
+                    <th>Vendor Name</th>
+                    <th>Market</th>
+                    <th>Bought or Caught</th>
+                    <th>How was it sold?</th>
+                    <th>Timestamp</th>
+                    <th>Detail</th>
+                </tr>
                 <tr ng-repeat="respondent in respondents">
                     <td>{{ respondent.user.username }}</td>
-                    <td>TODO: MARKET NAME GOES HERE</td>
+                    <td>{{ respondent.vendor }}</td>
+                    <td>{{ respondent.survey_site }}</td>
+                    <td>{{ respondent.buy_or_catch }}</td>
+                    <td>{{ respondent.how_sold }}</td>
                     <td>{{ respondent.ts|validDate: 'dd-MM-yyyy HH:mm' }}</td>
                     <td><a href="#/RespondantDetail/{{survey.slug}}/{{ respondent.uuid }}">Responses ({{respondent.responses.length}})</a></td>
                 </tr>


### PR DESCRIPTION
Adds vendor name, bought or caught, how sold and the market the fish was sold in to the recent responses list. Someone yell at me about the table header if you don't like it. I've attached a screenshot to #34.

(Also I'm testing out the sprintly/github integration so we'll see how this goes.)

Fixes #34.
Fixes #35.
Fixes #44.
Fixes #43.
Fixes #41.
